### PR TITLE
Fix some UI accessibility issues known to me right now.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,6 @@
                     <label for="minValue">Min value:</label>
                     <input type="number" name="Minimum value" id="minValue" value="" disabled>
                 </div>
-                <br>
                 <div>
                     <label for="maxValue">Max value:</label>
                     <input type="number" name="Maximum value" id="maxValue" value="" disabled>

--- a/public/index.html
+++ b/public/index.html
@@ -14,11 +14,9 @@
         <h2>Sensory interface</h2>
 
         <h3>Data</h3>
-        Data in tab-delimited CSV format:<br>
+        <label for="dataInput">Data in tab-delimited CSV format:</label><br>
         <textarea id="dataInput" onblur="findMinAndMaxValues()">1	2	3
 4	5	6</textarea>
-        <br>
-        <br>
         <br>
         <h3>Options</h3>
 
@@ -26,16 +24,31 @@
         <div class="container-fluid">
             Values outside the range are truncated. For example, if the range is [1,10], a value of 12 is expressed as
             10.<br>
-            <input type="radio" id="autoOption" name="value_range" value="auto" onclick="onRadioChange(this)"
-                checked>Auto<br>
-            <input type="radio" id="manualOption" name="value_range" value="manual"
-                onclick="onRadioChange(this)">Manual<br>
-            Min value:
-            <input type="number" name="Minimum value" id="minValue" value="" disabled>
-            <br>
-            Max value:
-            <input type="number" name="Maximum value" id="maxValue" value="" disabled>
-
+            <fieldset>
+                <legend>Mode</legend>
+                <div>
+                    <input type="radio" id="autoOption" name="value_range" value="auto" onclick="onRadioChange(this)"
+                        checked>Auto<br>
+                    <label for="autoOption">Auto</label>
+                </div>
+                <div>
+                    <input type="radio" id="manualOption" name="value_range" value="manual"
+                        onclick="onRadioChange(this)">Manual<br>
+                    <label for="manualOption">Manual</label>
+                </div>
+            </fieldset>
+            <fieldset>
+                <legend>Value range</legend>
+                <div>
+                    <label for="minValue">Min value:</label>
+                    <input type="number" name="Minimum value" id="minValue" value="" disabled>
+                </div>
+                <br>
+                <div>
+                    <label for="maxValue">Max value:</label>
+                    <input type="number" name="Maximum value" id="maxValue" value="" disabled>
+                </div>
+            </fieldset>
             <br>
         </div>
         <div style="display: none;" aria-hidden="true">

--- a/public/index.html
+++ b/public/index.html
@@ -28,12 +28,12 @@
                 <legend>Mode</legend>
                 <div>
                     <input type="radio" id="autoOption" name="value_range" value="auto" onclick="onRadioChange(this)"
-                        checked>Auto<br>
+                        checked>
                     <label for="autoOption">Auto</label>
                 </div>
                 <div>
                     <input type="radio" id="manualOption" name="value_range" value="manual"
-                        onclick="onRadioChange(this)">Manual<br>
+                        onclick="onRadioChange(this)">
                     <label for="manualOption">Manual</label>
                 </div>
             </fieldset>


### PR DESCRIPTION
This PR fixes some UI accessibility issues by doing the following:
* labeling all input HTML UI elements by the "\<label\>" element.
* grouping the radio button options under "mode" grouping by the "\<fieldset\>" tag with the ">legent>" set to "mode", so the screen reader user will hear (when in focus mode), that the radio options is found under the "mode" grouping.
* grouping the "min value" and "max value" under "value range" grouping using the same technique as in the previous item.